### PR TITLE
Mark spectrum-era as deprecated in favor of net-configurator

### DIFF
--- a/spectrum-era/2-4-3-200/README.md
+++ b/spectrum-era/2-4-3-200/README.md
@@ -2,8 +2,11 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 # ERA switch automation using NVIDIA NVUE Collection
+![status](https://img.shields.io/badge/status-deprecated-red)
 ![release](https://img.shields.io/badge/release-v3.0.0-blue)
 ![architecture](https://img.shields.io/badge/architecture-2--4--3--200-green)
+
+> **Deprecated:** This directory has been superseded by [`net-configurator`](../../net-configurator). New work should use `net-configurator`; `spectrum-era` is retained for reference only and is no longer actively maintained.
 
 This repository contains the files to setup ERA configuration on the core switches. You can change the values in the inventory files to customize the variables.
 

--- a/spectrum-era/2-8-5-200/README.md
+++ b/spectrum-era/2-8-5-200/README.md
@@ -2,8 +2,11 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 # ERA switch automation using NVIDIA NVUE Collection
+![status](https://img.shields.io/badge/status-deprecated-red)
 ![release](https://img.shields.io/badge/release-v3.0.0-blue)
 ![architecture](https://img.shields.io/badge/architecture-2--8--5--200-green)
+
+> **Deprecated:** This directory has been superseded by [`net-configurator`](../../net-configurator). New work should use `net-configurator`; `spectrum-era` is retained for reference only and is no longer actively maintained.
 
 This repository contains the files to setup ERA configuration on the core switches. You can change the values in the inventory files to customize the variables.
 

--- a/spectrum-era/2-8-9-400/README.md
+++ b/spectrum-era/2-8-9-400/README.md
@@ -2,8 +2,11 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 # ERA switch automation using NVIDIA NVUE Collection
+![status](https://img.shields.io/badge/status-deprecated-red)
 ![release](https://img.shields.io/badge/release-v3.0.0-blue)
 ![architecture](https://img.shields.io/badge/architecture-2--8--9--400-green)
+
+> **Deprecated:** This directory has been superseded by [`net-configurator`](../../net-configurator). New work should use `net-configurator`; `spectrum-era` is retained for reference only and is no longer actively maintained.
 
 This repository contains the files to setup ERA configuration on the core switches. You can change the values in the inventory files to customize the variables.
 

--- a/spectrum-era/README.md
+++ b/spectrum-era/README.md
@@ -3,6 +3,8 @@
 
 # ERA switch automation using NVIDIA NVUE Collection
 
+> **Deprecated:** This directory has been superseded by [`net-configurator`](../net-configurator). New work should use `net-configurator`; `spectrum-era` is retained for reference only and is no longer actively maintained.
+
 This repository contains the files to set up ERA configuration on the core switches. You can change the values in the inventory files to customize the variables.
 
 Please see each individual folder for configuration specific to that deployment type.


### PR DESCRIPTION
Add deprecation banner to spectrum-era/README.md and to each architecture README (2-4-3-200, 2-8-5-200, 2-8-9-400). Architecture READMEs also gain a status-deprecated shields.io badge so the status is visible at a glance for users who land directly on a release tag.